### PR TITLE
Fix spotlight animation

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1,5 +1,9 @@
 /* Dim non-active markdown panes */
 .workspace-leaf:not(.mod-active) .workspace-leaf-content[data-type='markdown'] {
     opacity: 0.75;
+}
+
+/* Apply opacity transition to all panes */
+.workspace-leaf .workspace-leaf-content[data-type='markdown'] {
     transition: opacity 0.25s ease-out;
 }


### PR DESCRIPTION
The spotlight was animating when turning off, but when turning on.  The fix is to update the CSS rules to make sure the transition applies to all panes, not just the inactive panes.