### PR TITLE
Prevent overlapping panes from showing through

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1,5 +1,5 @@
 /* Give the parent element a background color so overlapping panes don't show through */
-.workspace-leaf:not(.mod-active) {
+.workspace-leaf {
     background-color: inherit;
 }
 


### PR DESCRIPTION
This fixes #4.  The fix is to give the `.workspace-leaf` element a solid background color so that it conceals the pane underneath.